### PR TITLE
[Bugfix] [Github Workflow] fatal, not a valid branch name

### DIFF
--- a/.github/workflows/updateChangelog.yml
+++ b/.github/workflows/updateChangelog.yml
@@ -32,5 +32,5 @@ jobs:
           title: "Update CHANGELOG"
           body: |
             This pull request updates the CHANGELOG.md file with the changes from the recently merged pull request.
-          branch: changelog-update-$(date +'%Y-%m-%d-%H-%M-%S')
+          branch: changelog-update-$(date '+%Y-%m-%d-%H-%M-%S')
           labels: gh-workflow-bot


### PR DESCRIPTION
Automatically fixed by OpenAI using this same extension in VS Code 🤞🏼 
Part of #16