### PR TITLE
Do not specify the branch name in GH Workflow

### DIFF
--- a/.github/workflows/updateChangelog.yml
+++ b/.github/workflows/updateChangelog.yml
@@ -32,5 +32,4 @@ jobs:
           title: "Update CHANGELOG"
           body: |
             This pull request updates the CHANGELOG.md file with the changes from the recently merged pull request.
-          branch: changelog-update-$(date +%Y-%m-%d-%H-%M-%S)
           labels: gh-workflow-bot


### PR DESCRIPTION
Part of #16